### PR TITLE
GUA-854: Enlarge target area for service nav links

### DIFF
--- a/dist/service-header.css
+++ b/dist/service-header.css
@@ -732,7 +732,6 @@
 @media (min-width: 40.0625em) {
   .service-header__nav-list-item {
     display: inline-block;
-    padding: 15px 0 15px;
     margin: 0 30px 0 0;
     border-bottom: 5px solid transparent;
   }
@@ -807,4 +806,13 @@
 }
 .service-header__nav-list-item-link:not(:hover) {
   text-decoration: none;
+}
+@media (min-width: 40.0625em) {
+  .service-header__nav-list-item-link {
+    display: inline-block;
+    padding: 15px 0 15px;
+  }
+  .service-header__nav-list-item-link:focus {
+    box-shadow: 0 -5px #ffdd00, 0 5px #0b0c0c;
+  }
 }

--- a/dist/service-header.scss
+++ b/dist/service-header.scss
@@ -396,7 +396,6 @@ $govuk-header-link-underline-thickness: 3px;
 
   @include govuk-media-query ($from: tablet) {
     display: inline-block;
-    padding: govuk-spacing(3) 0 govuk-spacing(3);
     margin:  0 govuk-spacing(6) 0 0;
     border-bottom: govuk-spacing(1) solid transparent;
 
@@ -419,6 +418,15 @@ $govuk-header-link-underline-thickness: 3px;
 
   &:not(:hover) {
     text-decoration: none;
+  }
+  
+  @include govuk-media-query ($from: tablet) {
+    display: inline-block;
+    padding: govuk-spacing(3) 0 govuk-spacing(3);
+
+    &:focus {
+      box-shadow: 0 (-(govuk-spacing(1))) $govuk-focus-colour , 0 govuk-spacing(1) $govuk-focus-text-colour;
+    }
   }
 }
 // end service navigation styles

--- a/src/service-header.scss
+++ b/src/service-header.scss
@@ -396,7 +396,6 @@ $govuk-header-link-underline-thickness: 3px;
 
   @include govuk-media-query ($from: tablet) {
     display: inline-block;
-    padding: govuk-spacing(3) 0 govuk-spacing(3);
     margin:  0 govuk-spacing(6) 0 0;
     border-bottom: govuk-spacing(1) solid transparent;
 
@@ -419,6 +418,15 @@ $govuk-header-link-underline-thickness: 3px;
 
   &:not(:hover) {
     text-decoration: none;
+  }
+  
+  @include govuk-media-query ($from: tablet) {
+    display: inline-block;
+    padding: govuk-spacing(3) 0 govuk-spacing(3);
+
+    &:focus {
+      box-shadow: 0 (-(govuk-spacing(1))) $govuk-focus-colour , 0 govuk-spacing(1) $govuk-focus-text-colour;
+    }
   }
 }
 // end service navigation styles


### PR DESCRIPTION
There was some feedback suggesting improvements for the focus state on the service links on the One Login header.

The feedback was reviewed by UCD and there was agreement that the target area for the links should be increased to take up the entire height of the nav bar in the desktop variation of the header.

This eliminates the unsightly double border when an active link is focused.
https://govukverify.atlassian.net/browse/GUA-854

### Before
https://github.com/alphagov/di-govuk-one-login-service-header/assets/7116819/6147fcfe-ec69-4db1-a410-076aec56df7a

### After
https://github.com/alphagov/di-govuk-one-login-service-header/assets/7116819/0b147c87-679d-4808-98fe-7cddff83acae


