### PR TITLE
Update way active link is set in njk

### DIFF
--- a/dist/header.html
+++ b/dist/header.html
@@ -133,10 +133,10 @@
             <ul class="service-header__nav-list service-header__nav" id="service-header__nav" data-open-class="service-header__nav--open">
               
               <!-- Use the "service-header__nav-list-item--active" modifier class on the li to visually highlight the page the user is currently viewing -->
-              <li class="service-header__nav-list-item service-header__nav-list-item--active">
+              <li class="service-header__nav-list-item ">
                 <!-- Use the aria-current="page" attribute on the anchor tag -->
                 <a class="service-header__nav-list-item-link" 
-                   aria-current="page" 
+                  
                   href="#">
                   service link 1
                 </a>

--- a/dist/preview.html
+++ b/dist/preview.html
@@ -1,6 +1,7 @@
 
 
 
+
 <html lang="en">
   <head>
     <meta charset="UTF-8">
@@ -145,10 +146,10 @@
             <ul class="service-header__nav-list service-header__nav" id="service-header__nav" data-open-class="service-header__nav--open">
               
               <!-- Use the "service-header__nav-list-item--active" modifier class on the li to visually highlight the page the user is currently viewing -->
-              <li class="service-header__nav-list-item service-header__nav-list-item--active">
+              <li class="service-header__nav-list-item ">
                 <!-- Use the aria-current="page" attribute on the anchor tag -->
                 <a class="service-header__nav-list-item-link" 
-                   aria-current="page" 
+                  
                   href="#">
                   Example link 1
                 </a>
@@ -165,10 +166,10 @@
               </li>
               
               <!-- Use the "service-header__nav-list-item--active" modifier class on the li to visually highlight the page the user is currently viewing -->
-              <li class="service-header__nav-list-item ">
+              <li class="service-header__nav-list-item service-header__nav-list-item--active">
                 <!-- Use the aria-current="page" attribute on the anchor tag -->
                 <a class="service-header__nav-list-item-link" 
-                  
+                   aria-current="page" 
                   href="#">
                   Example link 3
                 </a>

--- a/src/preview.njk
+++ b/src/preview.njk
@@ -1,16 +1,19 @@
-{% set navigationItems = navigationItems if navigationItems else [
+{% set navigationItems = [
   {
-    active: true,
     href: "#",
-    text: 'Example link 1'
+    text: 'Example link 1',
+    id: 'id1'
   },{
     href: "#",
-    text: 'Example link 2'
+    text: 'Example link 2',
+    id: 'id2'
   },{
     href: "#",
-    text: 'Example link 3'
+    text: 'Example link 3',
+    id: 'id3'
   }]
 %}
+{% set activeLinkId = "id3" %}
 {% set serviceName = "Name of example service" %}
 
 <html lang="en">

--- a/src/service-header.njk
+++ b/src/service-header.njk
@@ -1,14 +1,16 @@
 {% set navigationItems = navigationItems if navigationItems else [
   {
-    active: true,
     href: "#",
-    text: 'service link 1'
+    text: 'service link 1',
+    id: 'servicelink1'
   },{
     href: "#",
-    text: 'service link 2'
+    text: 'service link 2',
+    id: 'servicelink2'
   },{
     href: "#",
-    text: 'service link 3'
+    text: 'service link 3',
+    id: 'servicelink3'
   }] %}
 {% set serviceName = serviceName if serviceName else "Name of service" %}
 {% macro littlePersonIcon(modifier="default") %}
@@ -102,10 +104,10 @@
             <ul class="service-header__nav-list service-header__nav" id="service-header__nav" data-open-class="service-header__nav--open">
               {% for item in navigationItems %}
               <!-- Use the "service-header__nav-list-item--active" modifier class on the li to visually highlight the page the user is currently viewing -->
-              <li class="service-header__nav-list-item {{ 'service-header__nav-list-item--active' if item.active else '' }}">
+              <li class="service-header__nav-list-item {{ 'service-header__nav-list-item--active' if (item.id == activeLinkId) else '' }}">
                 <!-- Use the aria-current="page" attribute on the anchor tag -->
                 <a class="service-header__nav-list-item-link" 
-                  {% if item.active %} aria-current="page" {% endif %}
+                  {% if (item.id == activeLinkId) %} aria-current="page" {% endif %}
                   href="{{item.href}}">
                   {{item.text}}
                 </a>


### PR DESCRIPTION
Set active link based on a separate parameter as opposed to as part of the navigation links array.

### How to set navigation links and active link (before)
```
{% set navigationItems = [
  {
    active: true,
    href: "#",
    text: 'Example link 1'
  },{
    href: "#",
    text: 'Example link 2'
  },{
    href: "#",
    text: 'Example link 3'
  }]
%}
```
You had to re-set `navigationItems` every time you want to set a different "active" state from the default.

### How to set navigation links and active link (after)

Set up navigation items in the main layout template. Navigation items must have a unique id, and be in the order you would like them to be displayed.

```
{% set navigationItems = [
  {
    href: "#",
    text: 'Example link 1',
    id: 'id1'
  },{
    href: "#",
    text: 'Example link 2',
    id: 'id2'
  },{
    href: "#",
    text: 'Example link 3',
    id: 'id3'
  }]
%}
```
To set the "active" link on individual pages, use the following syntax, where `activeLinkId` is the unique identifier for each link in the `navigationItems` array.

`{% set activeLinkId = "id3" %}`