### PR TITLE
replace AMF use placeholder sign out url

### DIFF
--- a/dist/html/header.html
+++ b/dist/html/header.html
@@ -79,7 +79,8 @@
             </a>
           </li>
           <li class="one-login-header__nav__list-item">
-            <a class="one-login-header__nav__link" href="https://home.account.gov.uk/sign-out">
+            <!-- REPLACE SIGN OUT URL PLACEHOLDER WITH SIGN OUT PAGE FOR YOUR SERVICE -->
+            <a class="one-login-header__nav__link" href="https://your-service-sign-out-url-goes-here.gov.uk">
               Sign out
             </a>
           </li>

--- a/dist/nunjucks/di-govuk-one-login-service-header/template.njk
+++ b/dist/nunjucks/di-govuk-one-login-service-header/template.njk
@@ -78,7 +78,8 @@ Component options:
             </a>
           </li>
           <li class="one-login-header__nav__list-item">
-            <a class="one-login-header__nav__link" href="https://home.account.gov.uk/sign-out">
+            <!-- REPLACE SIGN OUT URL PLACEHOLDER WITH SIGN OUT PAGE FOR YOUR SERVICE -->
+            <a class="one-login-header__nav__link" href="https://your-service-sign-out-url-goes-here.gov.uk">
               Sign out
             </a>
           </li>

--- a/dist/preview.html
+++ b/dist/preview.html
@@ -93,7 +93,8 @@
             </a>
           </li>
           <li class="one-login-header__nav__list-item">
-            <a class="one-login-header__nav__link" href="https://home.account.gov.uk/sign-out">
+            <!-- REPLACE SIGN OUT URL PLACEHOLDER WITH SIGN OUT PAGE FOR YOUR SERVICE -->
+            <a class="one-login-header__nav__link" href="https://your-service-sign-out-url-goes-here.gov.uk">
               Sign out
             </a>
           </li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "di-cross-service-header",
+  "name": "govuk-one-login-service-header",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "di-cross-service-header",
+      "name": "govuk-one-login-service-header",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/src/nunjucks/template.njk
+++ b/src/nunjucks/template.njk
@@ -78,7 +78,8 @@ Component options:
             </a>
           </li>
           <li class="one-login-header__nav__list-item">
-            <a class="one-login-header__nav__link" href="https://home.account.gov.uk/sign-out">
+            <!-- REPLACE SIGN OUT URL PLACEHOLDER WITH SIGN OUT PAGE FOR YOUR SERVICE -->
+            <a class="one-login-header__nav__link" href="https://your-service-sign-out-url-goes-here.gov.uk">
               Sign out
             </a>
           </li>


### PR DESCRIPTION
[https://govukverify.atlassian.net/browse/OLH-1004]
When a service implements the header, they need to update the sign out button link so that it points to their own sign out endpoint. They shouldn’t directly call the One Login endpoint from the header - that should happen later in their sign out flow.
