### PR TITLE
OLH-1045: Minor tweak to OL links alignment

### DIFF
--- a/dist/styles/service-header-no-imports.scss
+++ b/dist/styles/service-header-no-imports.scss
@@ -292,6 +292,7 @@ $govuk-header-link-underline-thickness: 3px;
   @include govuk-media-query ($from: tablet) {
     padding: govuk-spacing(2) 0 govuk-spacing(2) govuk-spacing(6);
     border-left: 1px solid $govuk-border-colour;
+    align-self: stretch;
 
     &:not(:last-child) {
       margin-right: govuk-spacing(4);

--- a/dist/styles/service-header.css
+++ b/dist/styles/service-header.css
@@ -556,6 +556,7 @@
   .one-login-header__nav__list-item {
     padding: 10px 0 10px 30px;
     border-left: 1px solid #b1b4b6;
+    align-self: stretch;
   }
   .one-login-header__nav__list-item:not(:last-child) {
     margin-right: 20px;

--- a/src/styles/service-header-no-imports.scss
+++ b/src/styles/service-header-no-imports.scss
@@ -292,6 +292,7 @@ $govuk-header-link-underline-thickness: 3px;
   @include govuk-media-query ($from: tablet) {
     padding: govuk-spacing(2) 0 govuk-spacing(2) govuk-spacing(6);
     border-left: 1px solid $govuk-border-colour;
+    align-self: stretch;
 
     &:not(:last-child) {
       margin-right: govuk-spacing(4);

--- a/src/styles/service-header.css
+++ b/src/styles/service-header.css
@@ -556,6 +556,7 @@
   .one-login-header__nav__list-item {
     padding: 10px 0 10px 30px;
     border-left: 1px solid #b1b4b6;
+    align-self: stretch;
   }
   .one-login-header__nav__list-item:not(:last-child) {
     margin-right: 20px;


### PR DESCRIPTION
Add `align-self` property to list items in the one login menu on the larger screen variation of the header. This is to ensure both list items are the same height AND are centred along the horizontal axis.

## Before (links slightly out of alignment)
![Screenshot 2023-08-21 at 17 06 47](https://github.com/alphagov/di-govuk-one-login-service-header/assets/7116819/594834c8-f345-42aa-b56f-1dc71623b79d)


## After (links in alignment)
<img width="1078" alt="Screenshot 2023-08-21 at 17 59 58" src="https://github.com/alphagov/di-govuk-one-login-service-header/assets/7116819/eb56bfe7-ce41-4e07-a91f-62ba568531ea">
