### PR TITLE
Update documentation for Nunjucks users

### DIFF
--- a/docs/prototype-kit-installation.md
+++ b/docs/prototype-kit-installation.md
@@ -44,6 +44,10 @@ The fields indicate as follows:
 
 To set the currently active link which indicates the page the user is currently on, use the following syntax <code>&lbrace;&percnt; set activeLinkId = "id3" &percnt;&rbrace;</code>. The value of `activeLinkId` must match the id of one of the objects in the `navigationItems` array.
 
+To overwrite the destination for the GOV.UK link in the header, use <code>&lbrace;&percnt; set homepageLink = "https://example.service.gov.uk/" &percnt;&rbrace;</code>. The link goes to "https://www.gov.uk/" by default.
+
+To overwrite the destination for the One Login link in the header, use <code>&lbrace;&percnt; set oneLoginLink = "https://example.service.gov.uk/" &percnt;&rbrace;</code>. The link goes to "https://home.account.gov.uk/" by default.
+
 Add the `set` statements listed above after the `extends` line at the top of the file.
 
 ## Use the header component in an existing page or template

--- a/src/nunjucks/template.njk
+++ b/src/nunjucks/template.njk
@@ -21,7 +21,10 @@ Component options:
       id: 'servicelink3'
     }] 
   - activeLinkId (string): The id of the link that is currently active 
+  - oneLoginLink (string): Option to overwrite the default One Login Home link. Defaults to "https://home.account.gov.uk/"
+  - homepageLink (string): Option to overwrite the default GOV.UK link. Defaults to "https://www.gov.uk/"
 #}
+
 {%- set oneLoginLink = params.oneLoginLink if params.oneLoginLink else "https://home.account.gov.uk/" -%}
 {%- set homepageLink = params.homepageLink if params.homepageLink else "https://www.gov.uk/" -%}
 {%- macro littlePersonIcon(modifier="default") -%}


### PR DESCRIPTION
I forgot to update the documentation when I added the option to overwrite the GOVUK and One Login links in the nunjucks macro in #21