### PR TITLE
Allow sign out link to be overriden

### DIFF
--- a/dist/html/header.html
+++ b/dist/html/header.html
@@ -80,7 +80,7 @@
           </li>
           <li class="one-login-header__nav__list-item">
             <!-- REPLACE SIGN OUT URL PLACEHOLDER WITH SIGN OUT PAGE FOR YOUR SERVICE -->
-            <a class="one-login-header__nav__link" href="https://your-service-sign-out-url-goes-here.gov.uk">
+            <a class="one-login-header__nav__link" href="https://home.account.gov.uk/sign-out">
               Sign out
             </a>
           </li>

--- a/dist/nunjucks/di-govuk-one-login-service-header/template.njk
+++ b/dist/nunjucks/di-govuk-one-login-service-header/template.njk
@@ -22,11 +22,13 @@ Component options:
     }] 
   - activeLinkId (string): The id of the link that is currently active 
   - oneLoginLink (string): Option to overwrite the default One Login Home link. Defaults to "https://home.account.gov.uk/"
-  - homepageLink (string): Option to overwrite the default GOV.UK link. Defaults to "https://www.gov.uk/"
+  - signOutLink (string): Option to overwrite the default signed out page. Defaults to "https://home.account.gov.uk/sign-out"
+  - homepageLink (string): Option to overwrite the default GOV.UK link. Defaults to "https://home.account.gov.uk/"
 #}
 
 {%- set oneLoginLink = params.oneLoginLink if params.oneLoginLink else "https://home.account.gov.uk/" -%}
 {%- set homepageLink = params.homepageLink if params.homepageLink else "https://www.gov.uk/" -%}
+{%- set signOutLink = params.signOutLink if params.signOutLink else "https://home.account.gov.uk/sign-out" -%}
 {%- macro littlePersonIcon(modifier="default") -%}
   {%- set class = "focus" if modifier == "focus" else "default" %}
   {%- set backgroundColour = "black" if modifier == "focus" else "white" %}
@@ -84,7 +86,7 @@ Component options:
           </li>
           <li class="one-login-header__nav__list-item">
             <!-- REPLACE SIGN OUT URL PLACEHOLDER WITH SIGN OUT PAGE FOR YOUR SERVICE -->
-            <a class="one-login-header__nav__link" href="https://your-service-sign-out-url-goes-here.gov.uk">
+            <a class="one-login-header__nav__link" href="{{ signOutLink }}">
               Sign out
             </a>
           </li>

--- a/dist/preview.html
+++ b/dist/preview.html
@@ -3,6 +3,7 @@
 
 
 
+
 <html lang="en">
   <head>
     <meta charset="UTF-8">
@@ -110,7 +111,7 @@
           </li>
           <li class="one-login-header__nav__list-item">
             <!-- REPLACE SIGN OUT URL PLACEHOLDER WITH SIGN OUT PAGE FOR YOUR SERVICE -->
-            <a class="one-login-header__nav__link" href="https://your-service-sign-out-url-goes-here.gov.uk">
+            <a class="one-login-header__nav__link" href="#">
               Sign out
             </a>
           </li>

--- a/docs/prototype-kit-installation.md
+++ b/docs/prototype-kit-installation.md
@@ -48,6 +48,8 @@ To overwrite the destination for the GOV.UK link in the header, use <code>&lbrac
 
 To overwrite the destination for the One Login link in the header, use <code>&lbrace;&percnt; set oneLoginLink = "https://example.service.gov.uk/" &percnt;&rbrace;</code>. The link goes to "https://home.account.gov.uk/" by default.
 
+To overwrite the destination for the sign out link in the header, use <code>&lbrace;&percnt; set signOutLink = "https://example.service.gov.uk/sign-out" &percnt;&rbrace;</code>. The link goes to "https://home.account.gov.uk/sign-out" by default.
+
 Add the `set` statements listed above after the `extends` line at the top of the file.
 
 ## Use the header component in an existing page or template

--- a/src/nunjucks/template.njk
+++ b/src/nunjucks/template.njk
@@ -22,11 +22,13 @@ Component options:
     }] 
   - activeLinkId (string): The id of the link that is currently active 
   - oneLoginLink (string): Option to overwrite the default One Login Home link. Defaults to "https://home.account.gov.uk/"
-  - homepageLink (string): Option to overwrite the default GOV.UK link. Defaults to "https://www.gov.uk/"
+  - signOutLink (string): Option to overwrite the default signed out page. Defaults to "https://home.account.gov.uk/sign-out"
+  - homepageLink (string): Option to overwrite the default GOV.UK link. Defaults to "https://home.account.gov.uk/"
 #}
 
 {%- set oneLoginLink = params.oneLoginLink if params.oneLoginLink else "https://home.account.gov.uk/" -%}
 {%- set homepageLink = params.homepageLink if params.homepageLink else "https://www.gov.uk/" -%}
+{%- set signOutLink = params.signOutLink if params.signOutLink else "https://home.account.gov.uk/sign-out" -%}
 {%- macro littlePersonIcon(modifier="default") -%}
   {%- set class = "focus" if modifier == "focus" else "default" %}
   {%- set backgroundColour = "black" if modifier == "focus" else "white" %}
@@ -84,7 +86,7 @@ Component options:
           </li>
           <li class="one-login-header__nav__list-item">
             <!-- REPLACE SIGN OUT URL PLACEHOLDER WITH SIGN OUT PAGE FOR YOUR SERVICE -->
-            <a class="one-login-header__nav__link" href="https://your-service-sign-out-url-goes-here.gov.uk">
+            <a class="one-login-header__nav__link" href="{{ signOutLink }}">
               Sign out
             </a>
           </li>

--- a/src/preview.njk
+++ b/src/preview.njk
@@ -16,6 +16,7 @@
 %}
 {% set activeLinkId = "id3" %}
 {% set serviceName = "Name of example service" %}
+{% set signOutLink = "#" %}
 
 <html lang="en">
   <head>
@@ -42,7 +43,7 @@
     </style>
   </head>
   <body style="margin:0;">
-    {{ govukOneLoginServiceHeader({ navigationItems: navigationItems, serviceName: serviceName, activeLinkId: activeLinkId }) }}
+    {{ govukOneLoginServiceHeader({ navigationItems: navigationItems, serviceName: serviceName, activeLinkId: activeLinkId, signOutLink: signOutLink }) }}
     <script src="./scripts/service-header.js"></script>
     <script>
       var oneLoginHeader = document.querySelector("[data-module='one-login-header']");


### PR DESCRIPTION
Current the "sign out" link is hardcoded to `https://your-service-sign-out-url-goes-here.gov.uk`.

This change allows the link to be overridden, and updates the default to `https://home.account.gov.uk/sign-out` (the live sign out link).

This is required for prototypes which are using the header, so that they can do user testing around the sign out flow.