### PR TITLE
OLH-1159: Prevent JS console error when header element not present + CSS tweak

### DIFF
--- a/dist/preview.html
+++ b/dist/preview.html
@@ -179,9 +179,6 @@
 </header>
 
     <script src="./scripts/service-header.js"></script>
-    <script>
-      var oneLoginHeader = document.querySelector("[data-module='one-login-header']");
-      new window.CrossServiceHeader(oneLoginHeader).init();
-    </script>
+    <script src="./scripts/init-service-header.js"></script>
   </body>
 </html>

--- a/dist/scripts/init-service-header.js
+++ b/dist/scripts/init-service-header.js
@@ -1,2 +1,4 @@
 var oneLoginHeader = document.querySelector("[data-module='one-login-header']");
-new window.CrossServiceHeader(oneLoginHeader).init();
+if (oneLoginHeader) {
+  new window.CrossServiceHeader(oneLoginHeader).init();
+}

--- a/dist/scripts/service-header.js
+++ b/dist/scripts/service-header.js
@@ -5,8 +5,11 @@
 */
 function CrossServiceHeader ($module) {
   this.$header = $module
-  this.$navigation = $module.querySelectorAll("[data-one-login-header-nav]")
-  this.$header.classList.add('js-enabled')
+  this.$navigation = $module && $module.querySelectorAll("[data-one-login-header-nav]")
+  this.$numberOfNavs = this.$navigation && this.$navigation.length
+  if (this.$header) {
+    this.$header.classList.add('js-enabled')
+  }
 }
 /**
 * Initialise header
@@ -15,7 +18,7 @@ function CrossServiceHeader ($module) {
 * missing then there's nothing to do so return early.
 */
 CrossServiceHeader.prototype.init = function () {
-  if (!this.$header && !this.$navigation.length) {
+  if (!this.$header && !this.$numberOfNavs) {
     return
   }
   /**
@@ -26,7 +29,7 @@ CrossServiceHeader.prototype.init = function () {
   * 2. an aria-controls attribute which can be mapped to the ID of the element
   * that should be hidden on mobile
   */ 
-  for (var i = 0; i < this.$navigation.length; i++) {
+  for (var i = 0; i < this.$numberOfNavs; i++) {
     var $nav = this.$navigation[i];
     $nav.$menuButton = $nav.querySelector('.js-x-header-toggle')
     

--- a/dist/styles/service-header-no-imports.scss
+++ b/dist/styles/service-header-no-imports.scss
@@ -64,7 +64,7 @@ $govuk-header-link-underline-thickness: 3px;
   min-width: max-content;
   border: 0;
   margin: 0;
-  padding: govuk-spacing(2) 0 govuk-spacing(2) govuk-spacing(4);
+  padding: govuk-spacing(2) 0 govuk-spacing(1) govuk-spacing(4);
   background: none;
 
   &:before {
@@ -345,6 +345,10 @@ $govuk-header-link-underline-thickness: 3px;
 .service-header__container {
   padding-top: govuk-spacing(1);
 
+  @include govuk-media-query ($until: tablet) {
+    margin-bottom: govuk-spacing(1);
+  }
+
   @include govuk-media-query ($from: tablet) {
     display: flex;
     flex-wrap: wrap;
@@ -379,7 +383,7 @@ $govuk-header-link-underline-thickness: 3px;
 }
 
 .service-header__nav-list-item {
-  margin: govuk-spacing(2) 0 govuk-spacing(4);
+  margin: govuk-spacing(3) 0 govuk-spacing(4);
 
   &.service-header__nav-list-item--active {
     padding-left: govuk-spacing(3);

--- a/dist/styles/service-header.css
+++ b/dist/styles/service-header.css
@@ -198,7 +198,7 @@
   min-width: max-content;
   border: 0;
   margin: 0;
-  padding: 10px 0 10px 20px;
+  padding: 10px 0 5px 20px;
   background: none;
 }
 .cross-service-header.js-enabled .cross-service-header__button {
@@ -600,6 +600,11 @@
 .service-header__container {
   padding-top: 5px;
 }
+@media (max-width: 40.0525em) {
+  .service-header__container {
+    margin-bottom: 5px;
+  }
+}
 @media (min-width: 40.0625em) {
   .service-header__container {
     display: flex;
@@ -725,7 +730,7 @@
 }
 
 .service-header__nav-list-item {
-  margin: 10px 0 20px;
+  margin: 15px 0 20px;
 }
 .service-header__nav-list-item.service-header__nav-list-item--active {
   padding-left: 15px;

--- a/src/preview.njk
+++ b/src/preview.njk
@@ -45,9 +45,6 @@
   <body style="margin:0;">
     {{ govukOneLoginServiceHeader({ navigationItems: navigationItems, serviceName: serviceName, activeLinkId: activeLinkId, signOutLink: signOutLink }) }}
     <script src="./scripts/service-header.js"></script>
-    <script>
-      var oneLoginHeader = document.querySelector("[data-module='one-login-header']");
-      new window.CrossServiceHeader(oneLoginHeader).init();
-    </script>
+    <script src="./scripts/init-service-header.js"></script>
   </body>
 </html>

--- a/src/scripts/init-service-header.js
+++ b/src/scripts/init-service-header.js
@@ -1,2 +1,4 @@
 var oneLoginHeader = document.querySelector("[data-module='one-login-header']");
-new window.CrossServiceHeader(oneLoginHeader).init();
+if (oneLoginHeader) {
+  new window.CrossServiceHeader(oneLoginHeader).init();
+}

--- a/src/scripts/service-header.js
+++ b/src/scripts/service-header.js
@@ -5,8 +5,11 @@
 */
 function CrossServiceHeader ($module) {
   this.$header = $module
-  this.$navigation = $module.querySelectorAll("[data-one-login-header-nav]")
-  this.$header.classList.add('js-enabled')
+  this.$navigation = $module && $module.querySelectorAll("[data-one-login-header-nav]")
+  this.$numberOfNavs = this.$navigation && this.$navigation.length
+  if (this.$header) {
+    this.$header.classList.add('js-enabled')
+  }
 }
 /**
 * Initialise header
@@ -15,7 +18,7 @@ function CrossServiceHeader ($module) {
 * missing then there's nothing to do so return early.
 */
 CrossServiceHeader.prototype.init = function () {
-  if (!this.$header && !this.$navigation.length) {
+  if (!this.$header && !this.$numberOfNavs) {
     return
   }
   /**
@@ -26,7 +29,7 @@ CrossServiceHeader.prototype.init = function () {
   * 2. an aria-controls attribute which can be mapped to the ID of the element
   * that should be hidden on mobile
   */ 
-  for (var i = 0; i < this.$navigation.length; i++) {
+  for (var i = 0; i < this.$numberOfNavs; i++) {
     var $nav = this.$navigation[i];
     $nav.$menuButton = $nav.querySelector('.js-x-header-toggle')
     

--- a/src/styles/service-header-no-imports.scss
+++ b/src/styles/service-header-no-imports.scss
@@ -64,7 +64,7 @@ $govuk-header-link-underline-thickness: 3px;
   min-width: max-content;
   border: 0;
   margin: 0;
-  padding: govuk-spacing(2) 0 govuk-spacing(2) govuk-spacing(4);
+  padding: govuk-spacing(2) 0 govuk-spacing(1) govuk-spacing(4);
   background: none;
 
   &:before {
@@ -345,6 +345,10 @@ $govuk-header-link-underline-thickness: 3px;
 .service-header__container {
   padding-top: govuk-spacing(1);
 
+  @include govuk-media-query ($until: tablet) {
+    margin-bottom: govuk-spacing(1);
+  }
+
   @include govuk-media-query ($from: tablet) {
     display: flex;
     flex-wrap: wrap;
@@ -379,7 +383,7 @@ $govuk-header-link-underline-thickness: 3px;
 }
 
 .service-header__nav-list-item {
-  margin: govuk-spacing(2) 0 govuk-spacing(4);
+  margin: govuk-spacing(3) 0 govuk-spacing(4);
 
   &.service-header__nav-list-item--active {
     padding-left: govuk-spacing(3);

--- a/src/styles/service-header.css
+++ b/src/styles/service-header.css
@@ -198,7 +198,7 @@
   min-width: max-content;
   border: 0;
   margin: 0;
-  padding: 10px 0 10px 20px;
+  padding: 10px 0 5px 20px;
   background: none;
 }
 .cross-service-header.js-enabled .cross-service-header__button {
@@ -600,6 +600,11 @@
 .service-header__container {
   padding-top: 5px;
 }
+@media (max-width: 40.0525em) {
+  .service-header__container {
+    margin-bottom: 5px;
+  }
+}
 @media (min-width: 40.0625em) {
   .service-header__container {
     display: flex;
@@ -725,7 +730,7 @@
 }
 
 .service-header__nav-list-item {
-  margin: 10px 0 20px;
+  margin: 15px 0 20px;
 }
 .service-header__nav-list-item.service-header__nav-list-item--active {
   padding-left: 15px;


### PR DESCRIPTION
[OLH-1159: Prevent uncaught type error](https://github.com/alphagov/di-govuk-one-login-service-header/commit/baeaa773a5fc3a1dd6c2af3b40ff0c686eee77d6) 

Currently if someone copies both `service-header.js` and `init-service-header.js` from us instead of writing their own JS to conditionally initialise the header in their code, and includes both on every page of their site (including pages which do not contain the OL header), there is a JS error on pages where the header is not present.
This fixes that issue.

[OLH-1159: slight CSS tweak for service name](https://github.com/alphagov/di-govuk-one-login-service-header/commit/3aa29cd91e298eb454df4c49bf612eb2f46de75d) 

Tweak the CSS so that the service name is better spaced in the OL header in the mobile variation in the absence of a service navigational menu.
When there is a service nav menu, it should look exactly the same as before.
When the nav displays with service name only, the visual spacing should now be more balanced than it was before

| Before  | After |
| ------------- | ------------- |
| <img width="379" alt="Screenshot 2023-10-20 at 16 43 53" src="https://github.com/alphagov/di-govuk-one-login-service-header/assets/7116819/83d53d9b-9dd4-450d-b5fc-df38ee659a09">  | <img width="378" alt="Screenshot 2023-10-20 at 16 43 18" src="https://github.com/alphagov/di-govuk-one-login-service-header/assets/7116819/61c79e31-c24d-489c-9e9d-46264fc6c25d">  |

-----

Reminder: focus on `src` when reviewing as `dist` is compiled/build files

