### PR TITLE
OLH-1043: Tweak service nav for 1 link scenario

### DIFF
--- a/dist/scripts/service-header.js
+++ b/dist/scripts/service-header.js
@@ -7,9 +7,6 @@ function CrossServiceHeader ($module) {
   this.$header = $module
   this.$navigation = $module && $module.querySelectorAll("[data-one-login-header-nav]")
   this.$numberOfNavs = this.$navigation && this.$navigation.length
-  if (this.$header) {
-    this.$header.classList.add('js-enabled')
-  }
 }
 /**
 * Initialise header
@@ -31,14 +28,17 @@ CrossServiceHeader.prototype.init = function () {
   */ 
   for (var i = 0; i < this.$numberOfNavs; i++) {
     var $nav = this.$navigation[i];
-    $nav.$menuButton = $nav.querySelector('.js-x-header-toggle')
+    $nav.$menuButton = $nav.querySelector('.js-x-header-toggle');
     
     $nav.$menu = $nav.$menuButton && $nav.querySelector(
       '#' + $nav.$menuButton.getAttribute('aria-controls')
-      )
-    if (!$nav.$menuButton || !$nav.$menu) {
-      return
+    );
+    $nav.menuItems = $nav.$menu && $nav.$menu.querySelectorAll('li');
+    if (!$nav.$menuButton || !$nav.$menu || $nav.menuItems.length < 2) {
+      return;
     }
+
+    $nav.classList.add("toggle-enabled");
     $nav.$menuOpenClass = $nav.$menu && $nav.$menu.dataset.openClass;
     $nav.$menuButtonOpenClass = $nav.$menuButton && $nav.$menuButton.dataset.openClass;
     $nav.$menuButtonOpenLabel = $nav.$menuButton && $nav.$menuButton.dataset.labelForShow;
@@ -47,7 +47,7 @@ CrossServiceHeader.prototype.init = function () {
     $nav.$menuButtonCloseText = $nav.$menuButton && $nav.$menuButton.dataset.textForHide;
     $nav.isOpen = false;
 
-    $nav.$menuButton.addEventListener('click', this.handleMenuButtonClick.bind($nav))
+    $nav.$menuButton.addEventListener('click', this.handleMenuButtonClick.bind($nav));
   }
 }
 
@@ -59,14 +59,14 @@ CrossServiceHeader.prototype.init = function () {
 * sync the accessibility state and menu button state
 */
 CrossServiceHeader.prototype.handleMenuButtonClick = function () {
-  this.isOpen = !this.isOpen
-  this.$menuOpenClass && this.$menu.classList.toggle(this.$menuOpenClass, this.isOpen)
-  this.$menuButtonOpenClass && this.$menuButton.classList.toggle(this.$menuButtonOpenClass, this.isOpen)
-  this.$menuButton.setAttribute('aria-expanded', this.isOpen)
+  this.isOpen = !this.isOpen;
+  this.$menuOpenClass && this.$menu.classList.toggle(this.$menuOpenClass, this.isOpen);
+  this.$menuButtonOpenClass && this.$menuButton.classList.toggle(this.$menuButtonOpenClass, this.isOpen);
+  this.$menuButton.setAttribute('aria-expanded', this.isOpen);
   if (this.$menuButtonCloseLabel && this.$menuButtonOpenLabel) {
-    this.$menuButton.setAttribute('aria-label', (this.isOpen ? this.$menuButtonCloseLabel : this.$menuButtonOpenLabel))
+    this.$menuButton.setAttribute('aria-label', (this.isOpen ? this.$menuButtonCloseLabel : this.$menuButtonOpenLabel));
   }
   if (this.$menuButtonCloseText && this.$menuButtonOpenText) {
-    this.$menuButton.innerHTML = this.isOpen ? this.$menuButtonCloseText : this.$menuButtonOpenText
+    this.$menuButton.innerHTML = this.isOpen ? this.$menuButtonCloseText : this.$menuButtonOpenText;
   }
 }

--- a/dist/styles/service-header-no-imports.scss
+++ b/dist/styles/service-header-no-imports.scss
@@ -25,7 +25,7 @@ $govuk-header-link-underline-thickness: 3px;
 @mixin nav-style($nav-open-class) {
   display: block;
   // if JS is unavailable, the nav links are expanded and the toggle button is hidden
-  .cross-service-header.js-enabled & {
+  .toggle-enabled & {
     display: none;
 
     &#{$nav-open-class} {
@@ -47,7 +47,7 @@ $govuk-header-link-underline-thickness: 3px;
 .cross-service-header__button {
   display: none;
 
-  .cross-service-header.js-enabled & {
+  .toggle-enabled & {
     display: inline;
     display: flex;
 

--- a/dist/styles/service-header.css
+++ b/dist/styles/service-header.css
@@ -201,12 +201,12 @@
   padding: 10px 0 5px 20px;
   background: none;
 }
-.cross-service-header.js-enabled .cross-service-header__button {
+.toggle-enabled .cross-service-header__button {
   display: inline;
   display: flex;
 }
 @media (min-width: 40.0625em) {
-  .cross-service-header.js-enabled .cross-service-header__button {
+  .toggle-enabled .cross-service-header__button {
     display: none;
   }
 }
@@ -513,14 +513,14 @@
 .one-login-header__nav {
   display: block;
 }
-.cross-service-header.js-enabled .one-login-header__nav {
+.toggle-enabled .one-login-header__nav {
   display: none;
 }
-.cross-service-header.js-enabled .one-login-header__nav.one-login-header__nav--open {
+.toggle-enabled .one-login-header__nav.one-login-header__nav--open {
   display: block;
 }
 @media (min-width: 40.0625em) {
-  .cross-service-header.js-enabled .one-login-header__nav {
+  .toggle-enabled .one-login-header__nav {
     display: block;
   }
 }
@@ -652,14 +652,14 @@
 .service-header__nav {
   display: block;
 }
-.cross-service-header.js-enabled .service-header__nav {
+.toggle-enabled .service-header__nav {
   display: none;
 }
-.cross-service-header.js-enabled .service-header__nav.service-header__nav--open {
+.toggle-enabled .service-header__nav.service-header__nav--open {
   display: block;
 }
 @media (min-width: 40.0625em) {
-  .cross-service-header.js-enabled .service-header__nav {
+  .toggle-enabled .service-header__nav {
     display: block;
   }
 }

--- a/src/scripts/service-header.js
+++ b/src/scripts/service-header.js
@@ -7,9 +7,6 @@ function CrossServiceHeader ($module) {
   this.$header = $module
   this.$navigation = $module && $module.querySelectorAll("[data-one-login-header-nav]")
   this.$numberOfNavs = this.$navigation && this.$navigation.length
-  if (this.$header) {
-    this.$header.classList.add('js-enabled')
-  }
 }
 /**
 * Initialise header
@@ -31,14 +28,17 @@ CrossServiceHeader.prototype.init = function () {
   */ 
   for (var i = 0; i < this.$numberOfNavs; i++) {
     var $nav = this.$navigation[i];
-    $nav.$menuButton = $nav.querySelector('.js-x-header-toggle')
+    $nav.$menuButton = $nav.querySelector('.js-x-header-toggle');
     
     $nav.$menu = $nav.$menuButton && $nav.querySelector(
       '#' + $nav.$menuButton.getAttribute('aria-controls')
-      )
-    if (!$nav.$menuButton || !$nav.$menu) {
-      return
+    );
+    $nav.menuItems = $nav.$menu && $nav.$menu.querySelectorAll('li');
+    if (!$nav.$menuButton || !$nav.$menu || $nav.menuItems.length < 2) {
+      return;
     }
+
+    $nav.classList.add("toggle-enabled");
     $nav.$menuOpenClass = $nav.$menu && $nav.$menu.dataset.openClass;
     $nav.$menuButtonOpenClass = $nav.$menuButton && $nav.$menuButton.dataset.openClass;
     $nav.$menuButtonOpenLabel = $nav.$menuButton && $nav.$menuButton.dataset.labelForShow;
@@ -47,7 +47,7 @@ CrossServiceHeader.prototype.init = function () {
     $nav.$menuButtonCloseText = $nav.$menuButton && $nav.$menuButton.dataset.textForHide;
     $nav.isOpen = false;
 
-    $nav.$menuButton.addEventListener('click', this.handleMenuButtonClick.bind($nav))
+    $nav.$menuButton.addEventListener('click', this.handleMenuButtonClick.bind($nav));
   }
 }
 
@@ -59,14 +59,14 @@ CrossServiceHeader.prototype.init = function () {
 * sync the accessibility state and menu button state
 */
 CrossServiceHeader.prototype.handleMenuButtonClick = function () {
-  this.isOpen = !this.isOpen
-  this.$menuOpenClass && this.$menu.classList.toggle(this.$menuOpenClass, this.isOpen)
-  this.$menuButtonOpenClass && this.$menuButton.classList.toggle(this.$menuButtonOpenClass, this.isOpen)
-  this.$menuButton.setAttribute('aria-expanded', this.isOpen)
+  this.isOpen = !this.isOpen;
+  this.$menuOpenClass && this.$menu.classList.toggle(this.$menuOpenClass, this.isOpen);
+  this.$menuButtonOpenClass && this.$menuButton.classList.toggle(this.$menuButtonOpenClass, this.isOpen);
+  this.$menuButton.setAttribute('aria-expanded', this.isOpen);
   if (this.$menuButtonCloseLabel && this.$menuButtonOpenLabel) {
-    this.$menuButton.setAttribute('aria-label', (this.isOpen ? this.$menuButtonCloseLabel : this.$menuButtonOpenLabel))
+    this.$menuButton.setAttribute('aria-label', (this.isOpen ? this.$menuButtonCloseLabel : this.$menuButtonOpenLabel));
   }
   if (this.$menuButtonCloseText && this.$menuButtonOpenText) {
-    this.$menuButton.innerHTML = this.isOpen ? this.$menuButtonCloseText : this.$menuButtonOpenText
+    this.$menuButton.innerHTML = this.isOpen ? this.$menuButtonCloseText : this.$menuButtonOpenText;
   }
 }

--- a/src/styles/service-header-no-imports.scss
+++ b/src/styles/service-header-no-imports.scss
@@ -25,7 +25,7 @@ $govuk-header-link-underline-thickness: 3px;
 @mixin nav-style($nav-open-class) {
   display: block;
   // if JS is unavailable, the nav links are expanded and the toggle button is hidden
-  .cross-service-header.js-enabled & {
+  .toggle-enabled & {
     display: none;
 
     &#{$nav-open-class} {
@@ -47,7 +47,7 @@ $govuk-header-link-underline-thickness: 3px;
 .cross-service-header__button {
   display: none;
 
-  .cross-service-header.js-enabled & {
+  .toggle-enabled & {
     display: inline;
     display: flex;
 

--- a/src/styles/service-header.css
+++ b/src/styles/service-header.css
@@ -201,12 +201,12 @@
   padding: 10px 0 5px 20px;
   background: none;
 }
-.cross-service-header.js-enabled .cross-service-header__button {
+.toggle-enabled .cross-service-header__button {
   display: inline;
   display: flex;
 }
 @media (min-width: 40.0625em) {
-  .cross-service-header.js-enabled .cross-service-header__button {
+  .toggle-enabled .cross-service-header__button {
     display: none;
   }
 }
@@ -513,14 +513,14 @@
 .one-login-header__nav {
   display: block;
 }
-.cross-service-header.js-enabled .one-login-header__nav {
+.toggle-enabled .one-login-header__nav {
   display: none;
 }
-.cross-service-header.js-enabled .one-login-header__nav.one-login-header__nav--open {
+.toggle-enabled .one-login-header__nav.one-login-header__nav--open {
   display: block;
 }
 @media (min-width: 40.0625em) {
-  .cross-service-header.js-enabled .one-login-header__nav {
+  .toggle-enabled .one-login-header__nav {
     display: block;
   }
 }
@@ -652,14 +652,14 @@
 .service-header__nav {
   display: block;
 }
-.cross-service-header.js-enabled .service-header__nav {
+.toggle-enabled .service-header__nav {
   display: none;
 }
-.cross-service-header.js-enabled .service-header__nav.service-header__nav--open {
+.toggle-enabled .service-header__nav.service-header__nav--open {
   display: block;
 }
 @media (min-width: 40.0625em) {
-  .cross-service-header.js-enabled .service-header__nav {
+  .toggle-enabled .service-header__nav {
     display: block;
   }
 }


### PR DESCRIPTION
## What

This tweaks the way the nav script works so that dropdown behaviour does not initialise unless at least 2 navigational links are present.
Ticket: https://govukverify.atlassian.net/browse/OLH-1043 

## Why

Some services might have only one service link in the service navigation. In this scenario it does not make sense to collapse navigation into a dropdown in the mobile variant. It was raised as an [issue](https://github.com/alphagov/di-govuk-one-login-service-header/issues/16) by a service and we agreed to implement it. 


## Before ("Menu" toggle always appears)
<img width="376" alt="Screenshot 2023-11-09 at 16 53 02" src="https://github.com/alphagov/di-govuk-one-login-service-header/assets/7116819/d508ec51-0545-4278-af28-e5060c6db05b">

## After ("Menu" toggle no longer appears when there is only one service link)
<img width="382" alt="Screenshot 2023-11-09 at 16 50 18" src="https://github.com/alphagov/di-govuk-one-login-service-header/assets/7116819/548ab710-4a7f-4e9c-8ba0-5f65b27ed9f7">


The design for wider screens and the design for the 2+ nav link scenario should remain unchanged.

## How to review 

Ignore `dist` because it's all build files. 

You can preview the current version of the header by cloning the repo and opening `/dist/preview.html` in a browser. To change the number of items in the nav, you can modify the `navigationItems` in `src/preview.njk` and run `npm run build-all` before your change is reflected in `/dist/preview.html`